### PR TITLE
Feat append chat media

### DIFF
--- a/src/main/java/com/memoryshade/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/memoryshade/domain/chat/controller/ChatController.java
@@ -2,6 +2,7 @@ package com.memoryshade.domain.chat.controller;
 
 import java.util.List;
 
+import com.memoryshade.domain.chat.dto.ChatMediaUploadResponseDto;
 import com.memoryshade.domain.chat.dto.ChatMessageResponseDto;
 import com.memoryshade.domain.chat.dto.ChatSessionCloseResponseDto;
 import com.memoryshade.domain.chat.dto.ChatSessionCreateResponseDto;
@@ -46,12 +47,28 @@ public class ChatController {
     );
   }
 
+  @PostMapping(
+      value = "/{sessionId}/media",
+      consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+  )
+  public ResponseEntity<ChatMediaUploadResponseDto> uploadChatMedia(
+      @AuthenticationPrincipal Long loginUserId,
+      @PathVariable Long sessionId,
+      @RequestPart("file") MultipartFile file
+  ) {
+    return ResponseEntity.ok(
+        chatService.uploadChatMedia(loginUserId, sessionId, file)
+    );
+  }
+
   @PostMapping("/{sessionId}/close")
   public ResponseEntity<ChatSessionCloseResponseDto> closeChatSession(
       @AuthenticationPrincipal Long loginUserId,
       @PathVariable Long sessionId
   ) {
-    return ResponseEntity.ok(chatService.closeChatSession(loginUserId, sessionId));
+    return ResponseEntity.ok(
+        chatService.closeChatSession(loginUserId, sessionId)
+    );
   }
 
   @GetMapping("/{sessionId}/messages")

--- a/src/main/java/com/memoryshade/domain/chat/dto/ChatMediaUploadResponseDto.java
+++ b/src/main/java/com/memoryshade/domain/chat/dto/ChatMediaUploadResponseDto.java
@@ -1,0 +1,12 @@
+package com.memoryshade.domain.chat.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ChatMediaUploadResponseDto(
+    @JsonProperty("media_url")
+    String mediaUrl
+) {
+}

--- a/src/main/java/com/memoryshade/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/memoryshade/domain/chat/exception/ChatErrorCode.java
@@ -14,7 +14,8 @@ public enum ChatErrorCode implements ErrorCode {
   CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 메시지를 찾을 수 없습니다"),
   EMPTY_AUDIO_FILE(HttpStatus.BAD_REQUEST, "음성 파일이 비어 있습니다"),
   STT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "음성 변환에 실패했습니다"),
-  AI_RESPONSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 응답 생성에 실패했습니다");
+  AI_RESPONSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AI 응답 생성에 실패했습니다"),
+  EMPTY_IMAGE_FILE(HttpStatus.BAD_REQUEST, "이미지 파일이 비어 있습니다");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/com/memoryshade/domain/chat/model/ChatSessionMedia.java
+++ b/src/main/java/com/memoryshade/domain/chat/model/ChatSessionMedia.java
@@ -1,0 +1,53 @@
+package com.memoryshade.domain.chat.model;
+
+import java.time.LocalDateTime;
+
+import com.memoryshade.domain.diary.model.MediaType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "chat_session_media")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatSessionMedia {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long chatSessionMediaId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "session_id", nullable = false)
+  private ChatSession session;
+
+  @Column(name = "media_url", nullable = false)
+  private String mediaUrl;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "media_type", nullable = false)
+  private MediaType mediaType;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Builder
+  public ChatSessionMedia(ChatSession session, String mediaUrl, MediaType mediaType) {
+    this.session = session;
+    this.mediaUrl = mediaUrl;
+    this.mediaType = mediaType;
+    this.createdAt = LocalDateTime.now();
+  }
+}

--- a/src/main/java/com/memoryshade/domain/chat/repository/ChatSessionMediaRepository.java
+++ b/src/main/java/com/memoryshade/domain/chat/repository/ChatSessionMediaRepository.java
@@ -1,0 +1,15 @@
+package com.memoryshade.domain.chat.repository;
+
+import java.util.List;
+
+import com.memoryshade.domain.chat.model.ChatSessionMedia;
+import org.springframework.data.repository.Repository;
+
+public interface ChatSessionMediaRepository extends Repository<ChatSessionMedia, Long> {
+
+  ChatSessionMedia save(ChatSessionMedia chatSessionMedia);
+
+  List<ChatSessionMedia> findAllBySession_SessionIdOrderByCreatedAtAsc(Long sessionId);
+
+  void deleteAll(Iterable<ChatSessionMedia> chatSessionMedias);
+}

--- a/src/main/java/com/memoryshade/domain/chat/service/ChatService.java
+++ b/src/main/java/com/memoryshade/domain/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.memoryshade.domain.chat.service;
 
+import com.memoryshade.domain.chat.dto.ChatMediaUploadResponseDto;
 import com.memoryshade.domain.chat.dto.ChatMessageResponseDto;
 import com.memoryshade.domain.chat.dto.ChatSessionCloseResponseDto;
 import com.memoryshade.domain.chat.dto.ChatSessionCreateResponseDto;
@@ -7,16 +8,21 @@ import com.memoryshade.domain.chat.dto.ChatVoiceResponseDto;
 import com.memoryshade.domain.chat.exception.ChatErrorCode;
 import com.memoryshade.domain.chat.model.ChatMessage;
 import com.memoryshade.domain.chat.model.ChatSession;
+import com.memoryshade.domain.chat.model.ChatSessionMedia;
 import com.memoryshade.domain.chat.model.SenderType;
 import com.memoryshade.domain.chat.repository.ChatMessageRepository;
+import com.memoryshade.domain.chat.repository.ChatSessionMediaRepository;
 import com.memoryshade.domain.chat.repository.ChatSessionRepository;
 import com.memoryshade.domain.diary.dto.DiaryCreateFromChatResponseDto;
 import com.memoryshade.domain.diary.model.Diary;
-import com.memoryshade.domain.diary.repository.DiaryRepository;
+import com.memoryshade.domain.diary.model.MediaType;
+import com.memoryshade.domain.diary.service.DiaryMediaService;
 import com.memoryshade.domain.diary.service.DiaryService;
+import com.memoryshade.domain.emotion.service.EmotionService;
 import com.memoryshade.domain.user.model.User;
 import com.memoryshade.domain.user.repository.UserRepository;
 import com.memoryshade.global.exception.ExceptionList;
+import com.memoryshade.global.file.FileStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -42,12 +48,15 @@ public class ChatService {
   private static final String DEFAULT_INITIAL_QUESTION = "안녕하세요. 오늘은 어떤 하루를 보내셨나요?";
 
   private final ChatSessionRepository sessionRepository;
+  private final ChatSessionMediaRepository chatSessionMediaRepository;
   private final ChatMessageRepository messageRepository;
   private final UserRepository userRepository;
-  private final DiaryRepository diaryRepository;
   private final DiaryService diaryService;
+  private final DiaryMediaService diaryMediaService;
+  private final EmotionService emotionService;
   private final OpenAiAudioTranscriptionModel sttModel;
   private final ChatClient chatClient;
+  private final FileStorageService fileStorageService;
 
   @Transactional
   public ChatSessionCreateResponseDto createChatSession(Long loginUserId) {
@@ -108,10 +117,7 @@ public class ChatService {
       throw new ExceptionList(ChatErrorCode.EMPTY_AUDIO_FILE);
     }
 
-    userRepository.getByUserId(loginUserId);
-
-    ChatSession session = sessionRepository.findById(sessionId)
-        .orElseThrow(() -> new ExceptionList(ChatErrorCode.CHAT_SESSION_NOT_FOUND));
+    ChatSession session = getOwnedSession(loginUserId, sessionId);
 
     String userText = transcribe(file);
 
@@ -131,15 +137,44 @@ public class ChatService {
   }
 
   @Transactional
-  public ChatSessionCloseResponseDto closeChatSession(Long loginUserId, Long sessionId) {
+  public ChatMediaUploadResponseDto uploadChatMedia(
+      Long loginUserId,
+      Long sessionId,
+      MultipartFile file
+  ) {
     if (loginUserId == null) {
       throw new ExceptionList(ChatErrorCode.UNAUTHORIZED_USER);
     }
 
-    userRepository.getByUserId(loginUserId);
+    if (file == null || file.isEmpty()) {
+      throw new ExceptionList(ChatErrorCode.EMPTY_IMAGE_FILE);
+    }
 
-    ChatSession session = sessionRepository.findById(sessionId)
-        .orElseThrow(() -> new ExceptionList(ChatErrorCode.CHAT_SESSION_NOT_FOUND));
+    ChatSession session = getOwnedSession(loginUserId, sessionId);
+
+    String mediaUrl = fileStorageService.uploadImage(file);
+
+    chatSessionMediaRepository.save(
+        ChatSessionMedia.builder()
+            .session(session)
+            .mediaUrl(mediaUrl)
+            .mediaType(MediaType.IMAGE)
+            .build()
+    );
+
+    return new ChatMediaUploadResponseDto(mediaUrl);
+  }
+
+  @Transactional
+  public ChatSessionCloseResponseDto closeChatSession(
+      Long loginUserId,
+      Long sessionId
+  ) {
+    if (loginUserId == null) {
+      throw new ExceptionList(ChatErrorCode.UNAUTHORIZED_USER);
+    }
+
+    ChatSession session = getOwnedSession(loginUserId, sessionId);
 
     List<ChatMessage> messages =
         messageRepository.findAllBySession_SessionIdOrderByCreatedAtAsc(session.getSessionId());
@@ -158,6 +193,18 @@ public class ChatService {
         session.getSessionDate()
     );
 
+    List<ChatSessionMedia> chatSessionMedias =
+        chatSessionMediaRepository.findAllBySession_SessionIdOrderByCreatedAtAsc(sessionId);
+
+    if (!chatSessionMedias.isEmpty()) {
+      diaryMediaService.createDiaryMediasFromChatSession(
+          diaryResponse.diaryId(),
+          chatSessionMedias
+      );
+    }
+
+    emotionService.createEmotionAnalysis(loginUserId, diaryResponse.diaryId());
+
     return new ChatSessionCloseResponseDto(
         diaryResponse.diaryId(),
         diaryResponse.diaryDate(),
@@ -165,11 +212,38 @@ public class ChatService {
     );
   }
 
+  @Transactional(readOnly = true)
+  public List<ChatMessageResponseDto> getChatMessages(Long loginUserId, Long sessionId) {
+    if (loginUserId == null) {
+      throw new ExceptionList(ChatErrorCode.UNAUTHORIZED_USER);
+    }
+
+    ChatSession session = getOwnedSession(loginUserId, sessionId);
+
+    return messageRepository.findAllBySession_SessionIdOrderByCreatedAtAsc(session.getSessionId())
+        .stream()
+        .map(ChatMessageResponseDto::from)
+        .toList();
+  }
+
+  private ChatSession getOwnedSession(Long loginUserId, Long sessionId) {
+    userRepository.getByUserId(loginUserId);
+
+    ChatSession session = sessionRepository.findById(sessionId)
+        .orElseThrow(() -> new ExceptionList(ChatErrorCode.CHAT_SESSION_NOT_FOUND));
+
+    if (!session.getUser().getUserId().equals(loginUserId)) {
+      throw new ExceptionList(ChatErrorCode.UNAUTHORIZED_USER);
+    }
+
+    return session;
+  }
+
   private String getYesterdayDiarySummary(Long userId) {
     LocalDate yesterday = LocalDate.now().minusDays(1);
 
     Optional<Diary> yesterdayDiary =
-        diaryRepository.findTopByUser_UserIdAndDiaryDateOrderByCreatedAtDesc(userId, yesterday);
+        diaryService.findTopDiaryByUserIdAndDiaryDate(userId, yesterday);
 
     return yesterdayDiary
         .map(Diary::getContentSummary)
@@ -181,19 +255,19 @@ public class ChatService {
       String result = chatClient.prompt()
           .messages(List.of(
               new SystemMessage("""
-                                    당신은 경증 치매 어르신의 하루 기록을 도와주는 AI입니다.
-                                    짧고 부드럽게 말하세요.
-                                    한 번에 질문은 하나만 하세요.
-                                    항상 공감부터 하고, 자연스럽게 회상을 유도하세요.
-                                    전날 기록을 참고해서 오늘 대화를 시작하는 첫 질문을 한 문장으로 생성하세요.
-                                    """),
+                  당신은 경증 치매 어르신의 하루 기록을 도와주는 AI입니다.
+                  짧고 부드럽게 말하세요.
+                  한 번에 질문은 하나만 하세요.
+                  항상 공감부터 하고, 자연스럽게 회상을 유도하세요.
+                  전날 기록을 참고해서 오늘 대화를 시작하는 첫 질문을 한 문장으로 생성하세요.
+                  """),
               new UserMessage("""
-                                    아래는 사용자의 전날 일기 요약입니다.
-                                    이 내용을 바탕으로 오늘 대화를 시작할 회상형 첫 질문을 만들어 주세요.
+                  아래는 사용자의 전날 일기 요약입니다.
+                  이 내용을 바탕으로 오늘 대화를 시작할 회상형 첫 질문을 만들어 주세요.
 
-                                    전날 일기 요약:
-                                    %s
-                                    """.formatted(previousDiarySummary))
+                  전날 일기 요약:
+                  %s
+                  """.formatted(previousDiarySummary))
           ))
           .call()
           .content();
@@ -240,10 +314,10 @@ public class ChatService {
           .collect(Collectors.toList());
 
       messages.add(0, new SystemMessage("""
-                    당신은 경증 치매 어르신의 하루 기록을 도와주는 AI입니다.
-                    짧고 부드럽게 말하고, 한 번에 질문은 하나만 하세요.
-                    항상 공감 후 질문하세요.
-                    """));
+          당신은 경증 치매 어르신의 하루 기록을 도와주는 AI입니다.
+          짧고 부드럽게 말하고, 한 번에 질문은 하나만 하세요.
+          항상 공감 후 질문하세요.
+          """));
 
       String result = chatClient.prompt()
           .messages(messages)
@@ -276,16 +350,16 @@ public class ChatService {
       String result = chatClient.prompt()
           .messages(List.of(
               new SystemMessage("""
-                                    당신은 경증 치매 어르신의 하루 대화를 요약하는 AI입니다.
-                                    사용자의 하루를 중심으로 핵심 사건, 감정, 활동을 2~3문장으로 간단히 요약하세요.
-                                    불필요한 설명 없이 일기 저장용 요약만 작성하세요.
-                                    """),
+                  당신은 경증 치매 어르신의 하루 대화를 요약하는 AI입니다.
+                  사용자의 하루를 중심으로 핵심 사건, 감정, 활동을 2~3문장으로 간단히 요약하세요.
+                  불필요한 설명 없이 일기 저장용 요약만 작성하세요.
+                  """),
               new UserMessage("""
-                                    아래 대화 내용을 바탕으로 오늘 하루 기록을 요약해 주세요.
+                  아래 대화 내용을 바탕으로 오늘 하루 기록을 요약해 주세요.
 
-                                    대화 내용:
-                                    %s
-                                    """.formatted(fullConversation))
+                  대화 내용:
+                  %s
+                  """.formatted(fullConversation))
           ))
           .call()
           .content();
@@ -300,32 +374,6 @@ public class ChatService {
     }
   }
 
-  /**
-   * 특정 채팅 세션의 전체 메시지 내역을 조회합니다.
-   */
-  @Transactional(readOnly = true)
-  public List<ChatMessageResponseDto> getChatMessages(Long loginUserId, Long sessionId) {
-    // 1. 사용자 인증 확인
-    if (loginUserId == null) {
-      throw new ExceptionList(ChatErrorCode.UNAUTHORIZED_USER);
-    }
-
-    // 2. 세션 존재 확인
-    ChatSession session = sessionRepository.findById(sessionId)
-        .orElseThrow(() -> new ExceptionList(ChatErrorCode.CHAT_SESSION_NOT_FOUND));
-
-    // 3. 세션 소유권 확인 (보안)
-    if (!session.getUser().getUserId().equals(loginUserId)) {
-      throw new ExceptionList(ChatErrorCode.UNAUTHORIZED_USER);
-    }
-
-    // 4. 메시지 목록 조회 및 DTO 변환
-    return messageRepository.findAllBySession_SessionIdOrderByCreatedAtAsc(sessionId)
-        .stream()
-        .map(ChatMessageResponseDto::from)
-        .toList();
-  }
-
   private ChatMessage saveMessage(ChatSession session, SenderType type, String content) {
     return messageRepository.save(
         ChatMessage.builder()
@@ -335,4 +383,5 @@ public class ChatService {
             .build()
     );
   }
+
 }

--- a/src/main/java/com/memoryshade/domain/diary/controller/DiaryMediaController.java
+++ b/src/main/java/com/memoryshade/domain/diary/controller/DiaryMediaController.java
@@ -1,0 +1,30 @@
+package com.memoryshade.domain.diary.controller;
+
+import com.memoryshade.domain.diary.dto.DiaryMediaReadResponseDto;
+import com.memoryshade.domain.diary.service.DiaryMediaService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/diaries")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+public class DiaryMediaController {
+
+  private final DiaryMediaService diaryMediaService;
+
+  @GetMapping("/{diaryId}/media")
+  public ResponseEntity<List<DiaryMediaReadResponseDto>> getDiaryMedias(
+      @AuthenticationPrincipal Long loginUserId,
+      @PathVariable Long diaryId
+  ) {
+    return ResponseEntity.ok(
+        diaryMediaService.getDiaryMedias(loginUserId, diaryId)
+    );
+  }
+}

--- a/src/main/java/com/memoryshade/domain/diary/dto/DiaryMediaReadResponseDto.java
+++ b/src/main/java/com/memoryshade/domain/diary/dto/DiaryMediaReadResponseDto.java
@@ -1,0 +1,27 @@
+package com.memoryshade.domain.diary.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.memoryshade.domain.diary.model.DiaryMedia;
+import com.memoryshade.domain.diary.model.MediaType;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record DiaryMediaReadResponseDto(
+    @JsonProperty("media_id")
+    Long mediaId,
+
+    @JsonProperty("media_url")
+    String mediaUrl,
+
+    @JsonProperty("media_type")
+    MediaType mediaType
+) {
+  public static DiaryMediaReadResponseDto fromDiaryMedia(DiaryMedia diaryMedia) {
+    return new DiaryMediaReadResponseDto(
+        diaryMedia.getMediaId(),
+        diaryMedia.getMediaUrl(),
+        diaryMedia.getMediaType()
+    );
+  }
+}

--- a/src/main/java/com/memoryshade/domain/diary/repository/DiaryMediaRepository.java
+++ b/src/main/java/com/memoryshade/domain/diary/repository/DiaryMediaRepository.java
@@ -1,0 +1,13 @@
+package com.memoryshade.domain.diary.repository;
+
+import com.memoryshade.domain.diary.model.DiaryMedia;
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface DiaryMediaRepository extends Repository<DiaryMedia, Long> {
+
+  DiaryMedia save(DiaryMedia diaryMedia);
+
+  List<DiaryMedia> findAllByDiary_DiaryId(Long diaryId);
+}

--- a/src/main/java/com/memoryshade/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/memoryshade/domain/diary/repository/DiaryRepository.java
@@ -24,4 +24,6 @@ public interface DiaryRepository extends Repository<Diary, Long> {
     List<Diary> findAllByUser_UserIdAndDiaryDateAndIsSharedTrue(Long userId, LocalDate date);
 
     Optional<Diary> findTopByUser_UserIdAndDiaryDateOrderByCreatedAtDesc(Long userId, LocalDate date);
+
+    Optional<Diary> findById(Long diaryId);
 }

--- a/src/main/java/com/memoryshade/domain/diary/service/DiaryMediaService.java
+++ b/src/main/java/com/memoryshade/domain/diary/service/DiaryMediaService.java
@@ -1,0 +1,71 @@
+package com.memoryshade.domain.diary.service;
+
+import com.memoryshade.domain.chat.model.ChatSessionMedia;
+import com.memoryshade.domain.diary.dto.DiaryMediaReadResponseDto;
+import com.memoryshade.domain.diary.exception.DiaryErrorCode;
+import com.memoryshade.domain.diary.model.Diary;
+import com.memoryshade.domain.diary.model.DiaryMedia;
+import com.memoryshade.domain.diary.repository.DiaryMediaRepository;
+import com.memoryshade.domain.diary.repository.DiaryRepository;
+import com.memoryshade.domain.guardianLink.exception.GuardianLinkErrorCode;
+import com.memoryshade.domain.guardianLink.repository.GuardianLinkRepository;
+import com.memoryshade.domain.user.model.Role;
+import com.memoryshade.domain.user.model.User;
+import com.memoryshade.domain.user.repository.UserRepository;
+import com.memoryshade.global.exception.ExceptionList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DiaryMediaService {
+
+  private final DiaryMediaRepository diaryMediaRepository;
+  private final DiaryRepository diaryRepository;
+  private final UserRepository userRepository;
+  private final GuardianLinkRepository guardianLinkRepository;
+
+  public void createDiaryMediasFromChatSession(Long diaryId, List<ChatSessionMedia> chatSessionMedias) {
+    Diary diary = diaryRepository.findById(diaryId)
+        .orElseThrow(() -> new ExceptionList(DiaryErrorCode.DIARY_NOT_FOUND));
+
+    for (ChatSessionMedia chatSessionMedia : chatSessionMedias) {
+      diaryMediaRepository.save(
+          DiaryMedia.builder()
+              .diary(diary)
+              .mediaUrl(chatSessionMedia.getMediaUrl())
+              .mediaType(chatSessionMedia.getMediaType())
+              .build()
+      );
+    }
+  }
+
+  @Transactional(readOnly = true)
+  public List<DiaryMediaReadResponseDto> getDiaryMedias(Long loginUserId, Long diaryId) {
+    User loginUser = userRepository.getByUserId(loginUserId);
+
+    Diary diary = diaryRepository.findById(diaryId)
+        .orElseThrow(() -> new IllegalArgumentException("일기를 찾을 수 없습니다."));
+
+    if (loginUser.getRole() == Role.USER) {
+      if (!diary.getUser().getUserId().equals(loginUserId)) {
+        throw new ExceptionList(GuardianLinkErrorCode.TARGET_USER_ONLY);
+      }
+    } else if (loginUser.getRole() == Role.GUARDIAN) {
+      guardianLinkRepository.validateLinked(diary.getUser().getUserId(), loginUserId);
+
+      if (!diary.isShared()) {
+        throw new IllegalArgumentException("공유되지 않은 일기입니다.");
+      }
+    }
+
+    return diaryMediaRepository.findAllByDiary_DiaryId(diaryId)
+        .stream()
+        .map(DiaryMediaReadResponseDto::fromDiaryMedia)
+        .toList();
+  }
+}

--- a/src/main/java/com/memoryshade/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/memoryshade/domain/diary/service/DiaryService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -101,5 +102,9 @@ public class DiaryService {
         Diary savedDiary = diaryRepository.save(diary);
 
         return DiaryCreateFromChatResponseDto.fromDiary(savedDiary);
+    }
+
+    public Optional<Diary> findTopDiaryByUserIdAndDiaryDate(Long userId, LocalDate date) {
+        return diaryRepository.findTopByUser_UserIdAndDiaryDateOrderByCreatedAtDesc(userId, date);
     }
 }

--- a/src/main/java/com/memoryshade/domain/emotion/controller/EmotionController.java
+++ b/src/main/java/com/memoryshade/domain/emotion/controller/EmotionController.java
@@ -1,6 +1,6 @@
 package com.memoryshade.domain.emotion.controller;
 
-import com.memoryshade.domain.diary.repository.DiaryRepository;
+import com.memoryshade.domain.emotion.dto.EmotionRecentReadResponseDto;
 import com.memoryshade.domain.emotion.service.EmotionService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
@@ -17,14 +17,23 @@ import org.springframework.web.bind.annotation.*;
 public class EmotionController {
 
   private final EmotionService emotionService;
-  private final DiaryRepository diaryRepository;
+
   @PostMapping("/{diaryId}/analyze")
   public ResponseEntity<String> analyze(
       @AuthenticationPrincipal Long loginUserId,
       @PathVariable Long diaryId
   ) {
     emotionService.createEmotionAnalysis(loginUserId, diaryId);
-
     return ResponseEntity.ok(diaryId + "번 일기에 대한 감정 분석이 시작되었습니다.");
+  }
+
+  @GetMapping
+  public ResponseEntity<EmotionRecentReadResponseDto> getRecentEmotionSummary(
+      @AuthenticationPrincipal Long loginUserId,
+      @RequestParam("user_id") Long userId
+  ) {
+    return ResponseEntity.ok(
+        emotionService.getRecentEmotionSummary(loginUserId, userId)
+    );
   }
 }

--- a/src/main/java/com/memoryshade/domain/emotion/dto/EmotionRecentItemResponseDto.java
+++ b/src/main/java/com/memoryshade/domain/emotion/dto/EmotionRecentItemResponseDto.java
@@ -1,0 +1,18 @@
+package com.memoryshade.domain.emotion.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record EmotionRecentItemResponseDto(
+    @JsonProperty("emotion_type")
+    String emotionType,
+
+    @JsonProperty("display_name")
+    String displayName,
+
+    @JsonProperty("score")
+    Integer score
+) {
+}

--- a/src/main/java/com/memoryshade/domain/emotion/dto/EmotionRecentReadResponseDto.java
+++ b/src/main/java/com/memoryshade/domain/emotion/dto/EmotionRecentReadResponseDto.java
@@ -1,0 +1,14 @@
+package com.memoryshade.domain.emotion.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record EmotionRecentReadResponseDto(
+    @JsonProperty("top_emotions")
+    List<EmotionRecentItemResponseDto> topEmotions
+) {
+}

--- a/src/main/java/com/memoryshade/domain/emotion/repository/EmotionAnalysisRepository.java
+++ b/src/main/java/com/memoryshade/domain/emotion/repository/EmotionAnalysisRepository.java
@@ -2,12 +2,21 @@ package com.memoryshade.domain.emotion.repository;
 
 import com.memoryshade.domain.diary.model.Diary;
 import com.memoryshade.domain.emotion.model.EmotionAnalysis;
-import org.springframework.data.repository.Repository; // 기본 Repository 사용
+import org.springframework.data.repository.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface EmotionAnalysisRepository extends Repository<EmotionAnalysis, Long> {
+
   EmotionAnalysis save(EmotionAnalysis emotionAnalysis);
 
   Optional<EmotionAnalysis> findByDiary(Diary diary);
-  
+
+  List<EmotionAnalysis> findAllByDiary_User_UserIdAndDiary_DiaryDateBetween(
+      Long userId,
+      LocalDate startDate,
+      LocalDate endDate
+  );
 }

--- a/src/main/java/com/memoryshade/domain/emotion/service/EmotionService.java
+++ b/src/main/java/com/memoryshade/domain/emotion/service/EmotionService.java
@@ -2,9 +2,18 @@ package com.memoryshade.domain.emotion.service;
 
 import com.memoryshade.domain.diary.model.Diary;
 import com.memoryshade.domain.diary.repository.DiaryRepository;
+import com.memoryshade.domain.emotion.dto.EmotionRecentItemResponseDto;
+import com.memoryshade.domain.emotion.dto.EmotionRecentReadResponseDto;
 import com.memoryshade.domain.emotion.dto.EmotionResponseDto;
+import com.memoryshade.domain.emotion.model.EmotionAnalysis;
 import com.memoryshade.domain.emotion.model.EmotionType;
 import com.memoryshade.domain.emotion.repository.EmotionAnalysisRepository;
+import com.memoryshade.domain.guardianLink.exception.GuardianLinkErrorCode;
+import com.memoryshade.domain.guardianLink.repository.GuardianLinkRepository;
+import com.memoryshade.domain.user.model.Role;
+import com.memoryshade.domain.user.model.User;
+import com.memoryshade.domain.user.repository.UserRepository;
+import com.memoryshade.global.exception.ExceptionList;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,6 +21,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -21,6 +33,8 @@ public class EmotionService {
 
   private final EmotionAnalysisRepository emotionAnalysisRepository;
   private final DiaryRepository diaryRepository;
+  private final UserRepository userRepository;
+  private final GuardianLinkRepository guardianLinkRepository;
   private final RestTemplate restTemplate;
 
   @Value("${ai.server.url}")
@@ -28,16 +42,13 @@ public class EmotionService {
 
   @Transactional
   public void createEmotionAnalysis(Long loginUserId, Long diaryId) {
-    // 1. 일기 존재 여부 및 권한 확인
     Diary diary = diaryRepository.getDiary(diaryId, loginUserId);
 
-    //  이미 분석 결과가 존재한다면 추가 분석을 진행 X
     if (emotionAnalysisRepository.findByDiary(diary).isPresent()) {
       log.info("Diary ID: {} - 이미 분석 결과가 존재하여 분석을 생략합니다.", diaryId);
       return;
     }
 
-    // 분석 결과가 없을 때만 AI 서버 호출 진행
     try {
       EmotionResponseDto response = restTemplate.postForObject(
           aiServerUrl,
@@ -52,6 +63,87 @@ public class EmotionService {
     } catch (Exception e) {
       log.error("AI 감정 분석 중 통신 오류 발생: {}", e.getMessage());
     }
+  }
+
+  @Transactional(readOnly = true)
+  public EmotionRecentReadResponseDto getRecentEmotionSummary(
+      Long loginGuardianId,
+      Long userId
+  ) {
+    if (loginGuardianId == null) {
+      throw new ExceptionList(GuardianLinkErrorCode.UNAUTHORIZED_GUARDIAN);
+    }
+
+    User guardian = userRepository.getByUserId(loginGuardianId);
+    if (guardian.getRole() != Role.GUARDIAN) {
+      throw new ExceptionList(GuardianLinkErrorCode.GUARDIAN_ONLY);
+    }
+
+    User targetUser = userRepository.getByUserId(userId);
+    if (targetUser.getRole() != Role.USER) {
+      throw new ExceptionList(GuardianLinkErrorCode.TARGET_USER_ONLY);
+    }
+
+    guardianLinkRepository.validateLinked(userId, loginGuardianId);
+
+    LocalDate endDate = LocalDate.now();
+    LocalDate startDate = endDate.minusDays(29);
+
+    List<EmotionAnalysis> analyses =
+        emotionAnalysisRepository.findAllByDiary_User_UserIdAndDiary_DiaryDateBetween(
+            userId,
+            startDate,
+            endDate
+        );
+
+    if (analyses.isEmpty()) {
+      return new EmotionRecentReadResponseDto(List.of());
+    }
+
+    int count = analyses.size();
+
+    List<EmotionRecentItemResponseDto> topEmotions = List.of(
+            new EmotionRecentItemResponseDto(
+                EmotionType.JOY.name(),
+                "행복",
+                Math.round((float) analyses.stream().mapToInt(EmotionAnalysis::getJoyScore).sum() / count)
+            ),
+            new EmotionRecentItemResponseDto(
+                EmotionType.SADNESS.name(),
+                "슬픔",
+                Math.round((float) analyses.stream().mapToInt(EmotionAnalysis::getSadnessScore).sum() / count)
+            ),
+            new EmotionRecentItemResponseDto(
+                EmotionType.ANGER.name(),
+                "분노",
+                Math.round((float) analyses.stream().mapToInt(EmotionAnalysis::getAngerScore).sum() / count)
+            ),
+            new EmotionRecentItemResponseDto(
+                EmotionType.ANXIETY.name(),
+                "불안",
+                Math.round((float) analyses.stream().mapToInt(EmotionAnalysis::getAnxietyScore).sum() / count)
+            ),
+            new EmotionRecentItemResponseDto(
+                EmotionType.EMBARRASSMENT.name(),
+                "당황",
+                Math.round((float) analyses.stream().mapToInt(EmotionAnalysis::getEmbarrassmentScore).sum() / count)
+            ),
+            new EmotionRecentItemResponseDto(
+                EmotionType.HURT.name(),
+                "상처",
+                Math.round((float) analyses.stream().mapToInt(EmotionAnalysis::getHurtScore).sum() / count)
+            ),
+            new EmotionRecentItemResponseDto(
+                EmotionType.NEUTRAL.name(),
+                "여유",
+                Math.round((float) analyses.stream().mapToInt(EmotionAnalysis::getNeutralScore).sum() / count)
+            )
+        ).stream()
+        .sorted(Comparator.comparingInt(EmotionRecentItemResponseDto::score).reversed())
+        .limit(3)
+        .toList();
+
+    return new EmotionRecentReadResponseDto(topEmotions);
   }
 
   private boolean isReliable(String topEmotion) {

--- a/src/main/java/com/memoryshade/global/file/FileStorageService.java
+++ b/src/main/java/com/memoryshade/global/file/FileStorageService.java
@@ -1,0 +1,7 @@
+package com.memoryshade.global.file;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileStorageService {
+  String uploadImage(MultipartFile file);
+}

--- a/src/main/java/com/memoryshade/global/file/LocalFileStorageService.java
+++ b/src/main/java/com/memoryshade/global/file/LocalFileStorageService.java
@@ -1,0 +1,61 @@
+package com.memoryshade.global.file;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Slf4j
+@Service
+public class LocalFileStorageService implements FileStorageService {
+
+  @Value("${file.upload-dir}")
+  private String uploadDir;
+
+  @Override
+  public String uploadImage(MultipartFile file) {
+    try {
+      if (file == null || file.isEmpty()) {
+        throw new IllegalArgumentException("업로드할 파일이 비어 있습니다.");
+      }
+
+      String originalFilename = file.getOriginalFilename();
+      log.info("파일 업로드 시작 - originalFilename={}, uploadDir={}", originalFilename, uploadDir);
+
+      String extension = getExtension(originalFilename);
+      String storedFilename = UUID.randomUUID() + "." + extension;
+
+      Path uploadPath = Paths.get(System.getProperty("user.dir"), uploadDir).toAbsolutePath().normalize();
+      Files.createDirectories(uploadPath);
+
+      Path targetPath = uploadPath.resolve(storedFilename);
+      file.transferTo(targetPath.toFile());
+
+      log.info("파일 업로드 완료 - savedPath={}", targetPath);
+
+      return "/uploads/" + storedFilename;
+
+    } catch (IOException e) {
+      log.error("파일 업로드 실패 - IO 예외", e);
+      throw new RuntimeException("파일 업로드에 실패했습니다.", e);
+    } catch (Exception e) {
+      log.error("파일 업로드 실패 - 예외 발생", e);
+      throw new RuntimeException("파일 업로드에 실패했습니다.", e);
+    }
+  }
+
+  private String getExtension(String filename) {
+    if (!StringUtils.hasText(filename) || !filename.contains(".")) {
+      return "jpg";
+    }
+
+    return filename.substring(filename.lastIndexOf('.') + 1);
+  }
+}


### PR DESCRIPTION
- 미디어 API 개발 ([/api/chat-sessions/{sessionId}/media]
  - chat_session_media 태이블 추가
  - 사유 : 대화 종료 시, diary 테이블이 생성되는데, 사진파일은 대화종료 이전에 받음. 따라서 diary_media 테이블이 생기기 전이기 때문에, chat_session_media에 묶어두고 close 시점에 diary로 확정해서 옮김.

- 30일치 감정분석 결과 보호자 조회 API ([/api/emotions]

- chat/close 시 감정분석도 함께 진행될 수 있도록 수정